### PR TITLE
docs: Update API Key documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=${HONEYCOMB_API_KEY}"
 
 If you don't have an API key handy, here is the [documentation](https://docs.honeycomb.io/get-started/configure/environments/manage-api-keys/#create-api-key).
 
-
 ### Run the app
 
 `./run`


### PR DESCRIPTION
## Which problem is this PR solving?

Outdated Documentation links

## Short description of the changes

This PR updates the Create API Key documentation link so users are sent directly to their desired section.

## How to verify that this has the expected result
