### PR TITLE
docs: removed instructions for running in gitpod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Honeycomb Academy: Sample Meminator App
 
-***This is a demo app, don't run it in production***
+***This is a demo app, don't run it in production.***
 
 This contains a sample application for use in Honeycomb Academy lab activities. This app has 4 services.
 
@@ -20,7 +20,7 @@ Hello! Welcome to the **Instrumenting with Java** course lab.
 
 ## Running the application
 
-To run this app, you can use GitPod or Codespaces.
+To run this app, you can use Codespaces.
 
 Once you run the application, you can send traces to Honeycomb. Then you can practice improving the instrumentation for better observability.
 
@@ -29,14 +29,6 @@ Once you run the application, you can send traces to Honeycomb. Then you can pra
 Open the repository on GitHub. Open the `<> Code` dropdown down menu.
 
 Select the `Codespaces` tab. Create a codespace on main.
-
-### GitPod setup
-
-Go to [Gitpod](https://gitpod.io/#https://github.com/honeycombio/academy-instrumentation-java) to open the repository.
-
-Confirm the workspace creation. You can work in the browser with VS Code Browser or in your local code editor. The default settings are acceptable. 
-
-Once you are in the code editor, run `docker compose up` in the code editor's terminal. To stop running the application, run `ctrl+c`. Then run `docker compose down` to remove the container.
 
 ### Local development setup
 
@@ -82,8 +74,6 @@ After making changes to a service, you can tell it to rebuild just that one:
 ### Try it out
 
 Visit [http://localhost:10114]()
-
-> If you are using **GitPod**, the address may not be localhost. When running, the VSC environment will ask you if you want to expose the ports to public. Select Yes, and you will see the external address and port 10114, to which you can then click the globe icon to show it on a new tab.
 
 Click the "GO" button. Then wait.
 

--- a/test
+++ b/test
@@ -1,0 +1,32 @@
+[
+  {
+    "resource": {
+      "attributes": {
+        "service.name": "backend-for-frontend",
+        "service.instance.id": "my-instance-id-1"
+      }
+    },
+    "spans": [
+      {
+        "trace_id": "377e551e3fa21466afaf594e759ca5cb",
+        "span_id": "055829413d2235c3",
+        "parent_id": "83d7d6a23bef51f7",
+        "name": "POST",
+        "timestamp": "2024-12-10T23:27:12.575Z",
+        "duration_ms": 300568.907716,
+        "attributes": {
+          "http.url": "null",
+          "app.phraseResponse": "null"
+        },
+        "events": [
+          {
+            "timestamp": "2024-12-10T23:32:13.143897296Z",
+            "attributes": {
+              "exception.message": "Headers Timeout Error"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Short description of the changes

Gitpod is being [retired on 10/15/25](https://ona.com/stories/gitpod-classic-payg-sunset). This PR removes instructions from the README on running the app in Gitpod (and adds a period to the end of a sentence, but that's just a grammatical error that bugged me).
